### PR TITLE
Remove CGO directives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,5 @@ jobs:
       - name: get dependencies
         run: make deps
 
-      - name: build
-        run: go build -v ./...
-
       - name: go test
-        run: LD_LIBRARY_PATH=../deps go test -v ./...
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 # Based on https://gist.github.com/trosendal/d4646812a43920bfe94e
 
-DEPLOC = https://github.com/spacemeshos/ed25519_bip32/releases/download
+DEPURL = https://github.com/spacemeshos/ed25519_bip32/releases/download
 DEPTAG = 1.0.6
 DEPLIB = libed25519_bip32
+DEPDIR = deps
 
 ifeq ($(OS),Windows_NT)
 #    MACHINE = WIN32
@@ -37,7 +38,13 @@ FN = $(DEPLIB)_$(PLATFORM).tar.gz
 # Download the platform-specific dynamic library we rely on
 .PHONY: deps
 deps:
-	@mkdir -p deps
+	@mkdir -p $(DEPDIR)
 	@# silent, show errors, fail fast, follow links
-	curl -sSfL $(DEPLOC)/v$(DEPTAG)/$(FN) -o deps/$(FN)
-	cd deps && tar -xzf $(FN) --exclude=LICENSE
+	curl -sSfL $(DEPURL)/v$(DEPTAG)/$(FN) -o deps/$(FN)
+	cd $(DEPDIR) && tar -xzf $(FN) --exclude=LICENSE
+
+REALDEPDIR = $(shell realpath $(DEPDIR))
+
+.PHONY: test
+test:
+	LD_LIBRARY_PATH=$(REALDEPDIR) go test -v -ldflags "-extldflags \"-L$(REALDEPDIR) -led25519_bip32\"" ./...

--- a/bip32/bip32.go
+++ b/bip32/bip32.go
@@ -3,8 +3,6 @@ package bip32
 // TODO: is it possible to read the C header info from the header file rather than hardcoding it here?
 
 /*
-	#cgo CFLAGS: -I../deps
-	#cgo LDFLAGS: -L../deps -led25519_bip32
 	#include <stdint.h>
 
 	/// derive_c does the same thing as the above function, but is intended for use over the CFFI.


### PR DESCRIPTION
These cause downstream compilation issues. Don't hardcode the directives here, instead they'll be specified in Makefile or CI config.