### PR TITLE
Makefile fixes for Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,34 +4,41 @@ DEPURL = https://github.com/spacemeshos/spacemesh-sdk/releases/download/
 DEPTAG = 0.0.1
 DEPLIB = spacemesh-sdk
 DEPDIR = deps
+REALDEPDIR = $(shell realpath $(DEPDIR))
 
 ifeq ($(OS),Windows_NT)
-#    MACHINE = WIN32
-    DEPFN = windows-amd64
-#    ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
-#        MACHINE += AMD64
-#    endif
-#    ifeq ($(PROCESSOR_ARCHITECTURE),x86)
-#        MACHINE += IA32
-#    endif
+#	MACHINE = WIN32
+	DEPFN = windows-amd64
+#	ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+#		MACHINE += AMD64
+#	endif
+#	ifeq ($(PROCESSOR_ARCHITECTURE),x86)
+#		MACHINE += IA32
+#	endif
 else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S),Linux)
-        MACHINE = linux
-    endif
-    ifeq ($(UNAME_S),Darwin)
-        MACHINE = macos
-    endif
-    UNAME_P := $(shell uname -p)
-    ifeq ($(UNAME_P),x86_64)
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		MACHINE = linux
+		CGO_LDFLAGS := -Wl,-rpath,$$ORIGIN
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		MACHINE = macos
+		CGO_LDFLAGS := -Wl,-rpath,@loader_path
+	endif
+
+	UNAME_P := $(shell uname -p)
+	ifeq ($(UNAME_P),x86_64)
 		PLATFORM = $(MACHINE)-amd64
-    endif
-#    ifneq ($(filter %86,$(UNAME_P)),)
-#        MACHINE += IA32
-#    endif
-    ifneq ($(filter arm%,$(UNAME_P)),)
-    	PLATFORM = $(MACHINE)-arm64
-    endif
+	endif
+#	ifneq ($(filter %86,$(UNAME_P)),)
+#		MACHINE += IA32
+#	endif
+	ifneq ($(filter arm%,$(UNAME_P)),)
+		PLATFORM = $(MACHINE)-arm64
+	endif
+	ifeq ($(UNAME_P), aarch64)
+		PLATFORM = $(MACHINE)-arm64
+	endif
 endif
 FN = $(DEPLIB)_$(PLATFORM).tar.gz
 
@@ -43,11 +50,14 @@ deps:
 	curl -sSfL $(DEPURL)/v$(DEPTAG)/$(FN) -o deps/$(FN)
 	cd $(DEPDIR) && tar -xzf $(FN) --exclude=LICENSE
 
-REALDEPDIR = $(shell realpath $(DEPDIR))
-
 .PHONY: test
 test:
 	CGO_CFLAGS="-I$(REALDEPDIR)" \
-	CGO_LDFLAGS="-L$(REALDEPDIR)" \
+	CGO_LDFLAGS="-L$(REALDEPDIR) $(CGO_LDFLAGS)" \
 	LD_LIBRARY_PATH=$(REALDEPDIR) \
-	go test -v -count 1 -ldflags "-extldflags \"-L$(REALDEPDIR) -led25519_bip32 -lspacemesh_remote_wallet\"" ./...
+	go test -v -count 1 ./...
+
+.PHONY: go-env
+go-env:
+	go env -w CGO_CFLAGS="-I$(REALDEPDIR)"
+	go env -w CGO_LDFLAGS="-L$(REALDEPDIR) $(CGO_LDFLAGS)"


### PR DESCRIPTION
This fixes some issues with building `smkeys` for macOS. Closes https://github.com/spacemeshos/smkeys/issues/6

It appears that the `spacemesh-sdk` for macos-arm64 is not correctly linked/built? I now receive the following error when I run `go test`:

```shell
$ make test
CGO_CFLAGS="-I/Users/fasmat/workspace/spacemesh/smcli/smkeys/deps" \
        CGO_LDFLAGS="-L/Users/fasmat/workspace/spacemesh/smcli/smkeys/deps -Wl,-rpath,@loader_path" \
        LD_LIBRARY_PATH=/Users/fasmat/workspace/spacemesh/smcli/smkeys/deps \
        go test -v -count 1 ./...
# github.com/spacemeshos/smkeys/remote-wallet.test
/opt/homebrew/Cellar/go/1.20.4/libexec/pkg/tool/darwin_arm64/link: running cc failed: exit status 1
Undefined symbols for architecture arm64:
  "_read_pubkey_from_ledger", referenced from:
      __cgo_aea739f3d698_Cfunc_read_pubkey_from_ledger in 000001.o
     (maybe you meant: __cgo_aea739f3d698_Cfunc_read_pubkey_from_ledger)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)

# github.com/spacemeshos/smkeys/bip32.test
/opt/homebrew/Cellar/go/1.20.4/libexec/pkg/tool/darwin_arm64/link: running cc failed: exit status 1
Undefined symbols for architecture arm64:
  "_derive_c", referenced from:
      __cgo_ed73c806f4ea_Cfunc_derive_c in 000001.o
     (maybe you meant: __cgo_ed73c806f4ea_Cfunc_derive_c)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)

FAIL    github.com/spacemeshos/smkeys/bip32 [build failed]
FAIL    github.com/spacemeshos/smkeys/remote-wallet [build failed]
FAIL
make: *** [test] Error 1
```